### PR TITLE
TCC profile xml fix

### DIFF
--- a/Source/Model/TCCProfile.swift
+++ b/Source/Model/TCCProfile.swift
@@ -150,7 +150,7 @@ struct TCCProfile : Codable {
         case displayName = "PayloadDisplayName"
         case identifier = "PayloadIdentifier"
         case organization = "PayloadOrganization"
-        case scope = "payloadScope"
+        case scope = "PayloadScope"
         case type = "PayloadType"
         case uuid = "PayloadUUID"
         case version = "PayloadVersion"
@@ -167,8 +167,8 @@ struct TCCProfile : Codable {
                               services: services)
         self.version = 1
         self.uuid = UUID().uuidString
-        self.type = content.type
-        self.scope = "system"
+        self.type = "Configuration"
+        self.scope = "System"
         self.organization = content.organization
         self.identifier = content.identifier
         self.displayName = content.displayName


### PR DESCRIPTION
Correct xml to use Configuration for the top level payload type
Correct xml to use camel case for PayloadScope key and System value.