### PR TITLE
Fixed #52 Adding duplicates to Apple Events

### DIFF
--- a/Resources/Base.lproj/Main.storyboard
+++ b/Resources/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="15702" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="15702"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16096"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -2089,7 +2089,6 @@
                                             <tableColumns>
                                                 <tableColumn width="482" minWidth="40" maxWidth="1000" id="ci3-gO-OVp">
                                                     <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border">
-                                                        <font key="font" metaFont="message" size="11"/>
                                                         <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                                     </tableHeaderCell>
@@ -2200,15 +2199,7 @@
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>
                                 <connections>
-                                    <binding destination="ZfI-PN-mks" name="enabled2" keyPath="canEdit" previousBinding="Tyh-kR-x77" id="QpF-JL-NEt">
-                                        <dictionary key="options">
-                                            <integer key="NSMultipleValuesPlaceholder" value="-1"/>
-                                            <integer key="NSNoSelectionPlaceholder" value="-1"/>
-                                            <integer key="NSNotApplicablePlaceholder" value="-1"/>
-                                            <integer key="NSNullPlaceholder" value="-1"/>
-                                        </dictionary>
-                                    </binding>
-                                    <binding destination="qId-iR-fmq" name="enabled" keyPath="canRemove" id="Tyh-kR-x77"/>
+                                    <binding destination="ZfI-PN-mks" name="enabled" keyPath="self.model.selectedExecutables.@count" id="8bJ-mH-iha"/>
                                     <segue destination="HiQ-kk-PBp" kind="sheet" identifier="UploadSegue" id="P4k-E0-f9D"/>
                                 </connections>
                             </button>
@@ -2219,15 +2210,7 @@
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>
                                 <connections>
-                                    <binding destination="ZfI-PN-mks" name="enabled2" keyPath="canEdit" previousBinding="Obq-1B-Xjr" id="qhC-zz-Wxm">
-                                        <dictionary key="options">
-                                            <integer key="NSMultipleValuesPlaceholder" value="-1"/>
-                                            <integer key="NSNoSelectionPlaceholder" value="-1"/>
-                                            <integer key="NSNotApplicablePlaceholder" value="-1"/>
-                                            <integer key="NSNullPlaceholder" value="-1"/>
-                                        </dictionary>
-                                    </binding>
-                                    <binding destination="qId-iR-fmq" name="enabled" keyPath="canRemove" id="Obq-1B-Xjr"/>
+                                    <binding destination="ZfI-PN-mks" name="enabled" keyPath="self.model.selectedExecutables.@count" id="ahk-eu-YBW"/>
                                     <segue destination="mUH-Fz-fcT" kind="sheet" identifier="SaveSegue" id="Voo-Oy-5J9"/>
                                 </connections>
                             </button>
@@ -2254,7 +2237,6 @@
                                             <tableColumns>
                                                 <tableColumn width="195" minWidth="40" maxWidth="1000" id="oNB-rR-rpb">
                                                     <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border">
-                                                        <font key="font" metaFont="message" size="11"/>
                                                         <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                                     </tableHeaderCell>
@@ -2627,7 +2609,6 @@
                                             <tableColumns>
                                                 <tableColumn width="195" minWidth="40" maxWidth="1000" id="iR9-ex-Cme">
                                                     <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border">
-                                                        <font key="font" metaFont="message" size="11"/>
                                                         <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                                     </tableHeaderCell>

--- a/Resources/Base.lproj/Main.storyboard
+++ b/Resources/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="15702" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16096"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="15702"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -2089,6 +2089,7 @@
                                             <tableColumns>
                                                 <tableColumn width="482" minWidth="40" maxWidth="1000" id="ci3-gO-OVp">
                                                     <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border">
+                                                        <font key="font" metaFont="toolTip"/>
                                                         <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                                     </tableHeaderCell>
@@ -2199,7 +2200,15 @@
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>
                                 <connections>
-                                    <binding destination="ZfI-PN-mks" name="enabled" keyPath="self.model.selectedExecutables.@count" id="VtE-Hn-azJ"/>
+                                    <binding destination="ZfI-PN-mks" name="enabled2" keyPath="canEdit" previousBinding="Tyh-kR-x77" id="QpF-JL-NEt">
+                                        <dictionary key="options">
+                                            <integer key="NSMultipleValuesPlaceholder" value="-1"/>
+                                            <integer key="NSNoSelectionPlaceholder" value="-1"/>
+                                            <integer key="NSNotApplicablePlaceholder" value="-1"/>
+                                            <integer key="NSNullPlaceholder" value="-1"/>
+                                        </dictionary>
+                                    </binding>
+                                    <binding destination="qId-iR-fmq" name="enabled" keyPath="canRemove" id="Tyh-kR-x77"/>
                                     <segue destination="HiQ-kk-PBp" kind="sheet" identifier="UploadSegue" id="P4k-E0-f9D"/>
                                 </connections>
                             </button>
@@ -2210,7 +2219,15 @@
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>
                                 <connections>
-                                    <binding destination="ZfI-PN-mks" name="enabled" keyPath="self.model.selectedExecutables.@count" id="bf0-rd-bOQ"/>
+                                    <binding destination="ZfI-PN-mks" name="enabled2" keyPath="canEdit" previousBinding="Obq-1B-Xjr" id="qhC-zz-Wxm">
+                                        <dictionary key="options">
+                                            <integer key="NSMultipleValuesPlaceholder" value="-1"/>
+                                            <integer key="NSNoSelectionPlaceholder" value="-1"/>
+                                            <integer key="NSNotApplicablePlaceholder" value="-1"/>
+                                            <integer key="NSNullPlaceholder" value="-1"/>
+                                        </dictionary>
+                                    </binding>
+                                    <binding destination="qId-iR-fmq" name="enabled" keyPath="canRemove" id="Obq-1B-Xjr"/>
                                     <segue destination="mUH-Fz-fcT" kind="sheet" identifier="SaveSegue" id="Voo-Oy-5J9"/>
                                 </connections>
                             </button>
@@ -2237,6 +2254,7 @@
                                             <tableColumns>
                                                 <tableColumn width="195" minWidth="40" maxWidth="1000" id="oNB-rR-rpb">
                                                     <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border">
+                                                        <font key="font" metaFont="toolTip"/>
                                                         <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                                     </tableHeaderCell>
@@ -2609,6 +2627,7 @@
                                             <tableColumns>
                                                 <tableColumn width="195" minWidth="40" maxWidth="1000" id="iR9-ex-Cme">
                                                     <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border">
+                                                        <font key="font" metaFont="toolTip"/>
                                                         <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                                     </tableHeaderCell>

--- a/Resources/Base.lproj/Main.storyboard
+++ b/Resources/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="15702" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="15702"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16096"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -2089,7 +2089,6 @@
                                             <tableColumns>
                                                 <tableColumn width="482" minWidth="40" maxWidth="1000" id="ci3-gO-OVp">
                                                     <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border">
-                                                        <font key="font" metaFont="toolTip"/>
                                                         <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                                     </tableHeaderCell>
@@ -2200,15 +2199,7 @@
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>
                                 <connections>
-                                    <binding destination="ZfI-PN-mks" name="enabled2" keyPath="canEdit" previousBinding="Tyh-kR-x77" id="QpF-JL-NEt">
-                                        <dictionary key="options">
-                                            <integer key="NSMultipleValuesPlaceholder" value="-1"/>
-                                            <integer key="NSNoSelectionPlaceholder" value="-1"/>
-                                            <integer key="NSNotApplicablePlaceholder" value="-1"/>
-                                            <integer key="NSNullPlaceholder" value="-1"/>
-                                        </dictionary>
-                                    </binding>
-                                    <binding destination="qId-iR-fmq" name="enabled" keyPath="canRemove" id="Tyh-kR-x77"/>
+                                    <binding destination="ZfI-PN-mks" name="enabled" keyPath="self.model.selectedExecutables.@count" id="VtE-Hn-azJ"/>
                                     <segue destination="HiQ-kk-PBp" kind="sheet" identifier="UploadSegue" id="P4k-E0-f9D"/>
                                 </connections>
                             </button>
@@ -2219,15 +2210,7 @@
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>
                                 <connections>
-                                    <binding destination="ZfI-PN-mks" name="enabled2" keyPath="canEdit" previousBinding="Obq-1B-Xjr" id="qhC-zz-Wxm">
-                                        <dictionary key="options">
-                                            <integer key="NSMultipleValuesPlaceholder" value="-1"/>
-                                            <integer key="NSNoSelectionPlaceholder" value="-1"/>
-                                            <integer key="NSNotApplicablePlaceholder" value="-1"/>
-                                            <integer key="NSNullPlaceholder" value="-1"/>
-                                        </dictionary>
-                                    </binding>
-                                    <binding destination="qId-iR-fmq" name="enabled" keyPath="canRemove" id="Obq-1B-Xjr"/>
+                                    <binding destination="ZfI-PN-mks" name="enabled" keyPath="self.model.selectedExecutables.@count" id="bf0-rd-bOQ"/>
                                     <segue destination="mUH-Fz-fcT" kind="sheet" identifier="SaveSegue" id="Voo-Oy-5J9"/>
                                 </connections>
                             </button>
@@ -2254,7 +2237,6 @@
                                             <tableColumns>
                                                 <tableColumn width="195" minWidth="40" maxWidth="1000" id="oNB-rR-rpb">
                                                     <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border">
-                                                        <font key="font" metaFont="toolTip"/>
                                                         <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                                     </tableHeaderCell>
@@ -2627,7 +2609,6 @@
                                             <tableColumns>
                                                 <tableColumn width="195" minWidth="40" maxWidth="1000" id="iR9-ex-Cme">
                                                     <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border">
-                                                        <font key="font" metaFont="toolTip"/>
                                                         <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                                     </tableHeaderCell>

--- a/Source/View Controllers/TCCProfileViewController.swift
+++ b/Source/View Controllers/TCCProfileViewController.swift
@@ -146,7 +146,7 @@ class TCCProfileViewController: NSViewController {
 
     @IBAction func addToExecutable(_ sender: NSButton) {
         promptForExecutables {
-            self.insetIntoAppleEvents($0)
+            self.insertIntoAppleEvents($0)
         }
     }
 
@@ -338,7 +338,7 @@ class TCCProfileViewController: NSViewController {
                     [weak self] result in
                     switch result {
                     case .success(let executable):
-                        self?.insetIntoAppleEvents(executable)
+                        self?.insertIntoAppleEvents(executable)
                     case .failure(let error):
                         self?.showAlert(error, for: window)
                         print(error)
@@ -348,13 +348,12 @@ class TCCProfileViewController: NSViewController {
         }
     }
     
-    func insetIntoAppleEvents(_ executable: Executable) {
+    func insertIntoAppleEvents(_ executable: Executable) {
         guard let source = self.executablesAC.selectedObjects.first as? Executable else { return }
         let rule = AppleEventRule(source: source, destination: executable, value: false)
-        if (self.shouldAppleEventRuleBeAdded(rule)) {
-            guard self.appleEventsAC.canInsert else { return }
-            self.appleEventsAC.insert(rule, atArrangedObjectIndex: 0)
-        }
+        guard self.appleEventsAC.canInsert,
+            self.shouldAppleEventRuleBeAdded(rule) else { return }
+        self.appleEventsAC.insert(rule, atArrangedObjectIndex: 0)
     }
     
     func shouldExecutableBeAdded(_ executable: Executable) -> Bool {
@@ -362,14 +361,11 @@ class TCCProfileViewController: NSViewController {
     }
     
     func shouldAppleEventRuleBeAdded(_ rule: AppleEventRule) -> Bool {
-        var found = false
         let selectedExe = self.model.selectedExecutables[self.executablesAC.selectionIndex]
-        for existingRule in selectedExe.appleEvents {
-            if (existingRule.destination == rule.destination) {
-                found = true
-            }
+        let foundRule = selectedExe.appleEvents.first {
+            $0.destination == rule.destination
         }
-        return !found
+        return foundRule == nil
     }
 }
 
@@ -405,7 +401,7 @@ extension TCCProfileViewController : NSTableViewDataSource {
                         self?.executablesAC.insert(newExecutable, atArrangedObjectIndex: row)
                     }
                 } else {
-                    self?.insetIntoAppleEvents(newExecutable)
+                    self?.insertIntoAppleEvents(newExecutable)
                 }
             case .failure(let error):
                 self?.showAlert(error, for: window)

--- a/Source/View Controllers/TCCProfileViewController.swift
+++ b/Source/View Controllers/TCCProfileViewController.swift
@@ -325,14 +325,28 @@ class TCCProfileViewController: NSViewController {
     func insetIntoAppleEvents(_ executable: Executable) {
         guard let source = self.executablesAC.selectedObjects.first as? Executable else { return }
         let rule = AppleEventRule(source: source, destination: executable, value: false)
-        guard self.appleEventsAC.canInsert else { return }
-        self.appleEventsAC.insert(rule, atArrangedObjectIndex: 0)
+        if (self.shouldAppleEventRuleBeAdded(rule)) {
+            guard self.appleEventsAC.canInsert else { return }
+            self.appleEventsAC.insert(rule, atArrangedObjectIndex: 0)
+        }
     }
     
     func shouldExecutableBeAdded(_ executable: Executable) -> Bool {
         return self.model.selectedExecutables.firstIndex(of: executable) == nil
     }
     
+    func shouldAppleEventRuleBeAdded(_ rule: AppleEventRule) -> Bool {
+        var found = false
+        let selectedExe = self.model.selectedExecutables[self.executablesAC.selectionIndex]
+        for existingRule in selectedExe.appleEvents {
+            if (existingRule.destination == rule.destination &&
+                existingRule.source == rule.source &&
+                existingRule.value == rule.value) {
+                found = true
+            }
+        }
+        return !found
+    }
 }
 
 extension TCCProfileViewController : NSTableViewDataSource {

--- a/Source/View Controllers/TCCProfileViewController.swift
+++ b/Source/View Controllers/TCCProfileViewController.swift
@@ -339,9 +339,7 @@ class TCCProfileViewController: NSViewController {
         var found = false
         let selectedExe = self.model.selectedExecutables[self.executablesAC.selectionIndex]
         for existingRule in selectedExe.appleEvents {
-            if (existingRule.destination == rule.destination &&
-                existingRule.source == rule.source &&
-                existingRule.value == rule.value) {
+            if (existingRule.destination == rule.destination) {
                 found = true
             }
         }


### PR DESCRIPTION
Added a check before an Apple Event is added to see if that rule already exists by checking for the destination among the currently selected Executable's Apple Event rules.

Fixed #52 