### PR TITLE
Fix the save workflow with keychain prompt

### DIFF
--- a/Source/View Controllers/SaveViewController.swift
+++ b/Source/View Controllers/SaveViewController.swift
@@ -80,7 +80,10 @@ class SaveViewController: NSViewController {
 
         panel.begin { response in
             if response == .OK {
-                self.saveTo(url: panel.url!)
+                // Let the save panel fully close itself before doing any work that may require keychain access.
+                DispatchQueue.main.async {
+                    self.saveTo(url: panel.url!)
+                }
             }
         }
     }


### PR DESCRIPTION
Fix so that the keychain prompt displays after the save panel is completely finished.

Closes #58 