### PR TITLE
Fix for implicit unwrapped optional - username

### DIFF
--- a/Source/View Controllers/UploadViewController.swift
+++ b/Source/View Controllers/UploadViewController.swift
@@ -81,7 +81,7 @@ class UploadViewController: NSViewController {
     @IBAction func uploadPressed(_ sender: NSButton) {
         print("Uploading profile: \(payloadName ?? "?")")
         self.networkOperationsTitle = "Uploading \(payloadName ?? "profile")"
-        
+
         guard let username = username, let password = password else {
             print("Username or password not set")
             Alert().display(header: "Attention:", message: "Username or password not set")
@@ -121,7 +121,7 @@ class UploadViewController: NSViewController {
             }
             return
         }
-        
+
         print("Checking connection")
         self.networkOperationsTitle = "Checking Jamf Pro server"
 
@@ -245,9 +245,9 @@ class UploadViewController: NSViewController {
     }
 
     func updateCredentialsAvailable() {
-        guard let username = username, !username.isEmpty
-              , let password = password, !password.isEmpty
-              , !jamfProServerLabel.stringValue.isEmpty else {
+        guard let username = username, !username.isEmpty,
+              let password = password, !password.isEmpty,
+              !jamfProServerLabel.stringValue.isEmpty else {
             if credentialsAvailable { credentialsAvailable = false }
             return
         }
@@ -260,7 +260,7 @@ class UploadViewController: NSViewController {
             if readyForUpload { readyForUpload = false}
             return
         }
-        
+
         guard readyForUpload != (
             credentialsVerified
             && credentialsAvailable

--- a/Source/View Controllers/UploadViewController.swift
+++ b/Source/View Controllers/UploadViewController.swift
@@ -264,7 +264,6 @@ class UploadViewController: NSViewController {
             credentialsVerified
             && credentialsAvailable
             && !organizationLabel.stringValue.isEmpty
-            && (payloadIdentifier != nil)
             && !payloadIdentifier.isEmpty
             && isSiteReadyToUpload())
             else { return }

--- a/Source/View Controllers/UploadViewController.swift
+++ b/Source/View Controllers/UploadViewController.swift
@@ -245,19 +245,18 @@ class UploadViewController: NSViewController {
     }
 
     func updateCredentialsAvailable() {
-        guard let username = username, !username.isEmpty,
-              let password = password, !password.isEmpty,
-              !jamfProServerLabel.stringValue.isEmpty else {
-            if credentialsAvailable { credentialsAvailable = false }
-            return
+        if let username = username, !username.isEmpty,
+           let password = password, !password.isEmpty,
+           !jamfProServerLabel.stringValue.isEmpty {
+            credentialsAvailable = true
+        } else {
+            credentialsAvailable = false
         }
-
-        if !credentialsAvailable { credentialsAvailable = true }
     }
 
     func updateReadForUpload() {
         guard let payloadName = payloadName, !payloadName.isEmpty else {
-            if readyForUpload { readyForUpload = false}
+            readyForUpload = false
             return
         }
 
@@ -359,10 +358,11 @@ class UploadViewController: NSViewController {
 
     func syncronizeCredentials() {
         if saveCredentials {
-            if credentialsAvailable {
+            if let username = username, let password = password, credentialsAvailable {
                 do {
-                    try SecurityWrapper.saveCredentials(username: username!,
-                                                        password: password!,
+
+                    try SecurityWrapper.saveCredentials(username: username,
+                                                        password: password,
                                                         server: jamfProServerLabel.stringValue)
                 } catch {
                     print("Failed to save credentials with error: \(error)")

--- a/Source/View Controllers/UploadViewController.swift
+++ b/Source/View Controllers/UploadViewController.swift
@@ -53,7 +53,7 @@ class UploadViewController: NSViewController {
     @objc dynamic var username: String?
     @objc dynamic var password: String?
     @objc dynamic var payloadName: String?
-    @objc dynamic var payloadIdentifier: String! = UUID().uuidString
+    @objc dynamic var payloadIdentifier = UUID().uuidString
     @objc dynamic var payloadDescription: String?
 
     @objc dynamic var site = false

--- a/Source/View Controllers/UploadViewController.swift
+++ b/Source/View Controllers/UploadViewController.swift
@@ -350,6 +350,7 @@ class UploadViewController: NSViewController {
                 }
             }
         } else {
+            guard username != nil else { return }
             try? SecurityWrapper.removeCredentials(server: jamfProServerLabel.stringValue, username: username)
         }
     }


### PR DESCRIPTION
This change fixes an app crash in case of cancelling an upload action.

Steps to reproduce the crash:
1. Add an app
2. Click on Upload
3. Uncheck save credentials
4. Click on cancel button