### PR TITLE
Drag and drop of applications now accepts multiple apps (#85)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 <!-- Add any information here about changes in master that have yet to be released -->
 ### Added
 - (@ty-wilson) Issue #79 Changed the property labels to match System Preferces with the MDM key listed in the help
+- (@macblazer) Issue #85 Application list and Apple Events app list both support multiple apps being dragged into the list.
 
 ### Fixed
 - (@ty-wilson) Fixed issue #54 where the code signing label was truncated

--- a/PPPC Utility.xcodeproj/project.pbxproj
+++ b/PPPC Utility.xcodeproj/project.pbxproj
@@ -95,6 +95,7 @@
 		6EC40A17214ECF2C00BE4F17 /* UploadViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadViewController.swift; sourceTree = "<group>"; };
 		6EC40A1B214EF87800BE4F17 /* SigningIdentity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SigningIdentity.swift; sourceTree = "<group>"; };
 		71061E53246106C800822D35 /* LoadExecutableError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadExecutableError.swift; sourceTree = "<group>"; };
+		97227C6726248CD7000F26C1 /* CHANGELOG.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
 		B5E09547250BCCFC00A40409 /* Alert.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Alert.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -199,6 +200,7 @@
 			isa = PBXGroup;
 			children = (
 				6E95730721553B650002C30B /* LICENSE */,
+				97227C6726248CD7000F26C1 /* CHANGELOG.md */,
 				6E5D5A1521541B8F00B43312 /* README.md */,
 				6EC409DC214D65BC00BE4F17 /* Source */,
 				5F95AE1423158EF0002E0A22 /* External */,

--- a/PPPC UtilityTests/ModelTests/ModelTests.swift
+++ b/PPPC UtilityTests/ModelTests/ModelTests.swift
@@ -42,58 +42,58 @@ class ModelTests: XCTestCase {
     // MARK: - tests for getExecutableFrom*
 
     func testGetExecutableBasedOnIdentifierAndCodeRequirement_BundleIdentifierType() {
-        //given
+        // given
             let identifier = "com.example.App"
             let codeRequirement = "testCodeRequirement"
 
-        //when
+        // when
             let executable = model.getExecutableFrom(identifier: identifier, codeRequirement: codeRequirement)
 
-        //then
+        // then
             XCTAssertEqual(executable.displayName, "App")
             XCTAssertEqual(executable.codeRequirement, codeRequirement)
             XCTAssertEqual(executable.iconPath, IconFilePath.application)
     }
 
     func testGetExecutableBasedOnIdentifierAndCodeRequirement_PathIdentifierType() {
-        //given
+        // given
         let identifier = "/myGreatPath/Awesome/Binary"
         let codeRequirement = "testCodeRequirement"
 
-        //when
+        // when
         let executable = model.getExecutableFrom(identifier: identifier, codeRequirement: codeRequirement)
 
-        //then
+        // then
         XCTAssertEqual(executable.displayName, "Binary")
         XCTAssertEqual(executable.codeRequirement, codeRequirement)
         XCTAssertEqual(executable.iconPath, IconFilePath.binary)
     }
 
     func testGetExecutableFromComputerBasedOnIdentifier() {
-        //given
+        // given
             let identifier = "com.apple.Safari"
             let codeRequirement = "randomReq"
 
-        //when
+        // when
             let executable = model.getExecutableFrom(identifier: identifier, codeRequirement: codeRequirement)
 
-        //then
+        // then
             XCTAssertEqual(executable.displayName, "Safari")
             XCTAssertNotEqual(executable.iconPath, IconFilePath.application)
             XCTAssertNotEqual(codeRequirement, executable.codeRequirement)
     }
 
     func testGetExecutableFromSelectedExecutables() {
-        //given
+        // given
         let expectedIdentifier = "com.something.1"
         let executable = model.getExecutableFrom(identifier: expectedIdentifier, codeRequirement: "testReq")
         let executableSecond = model.getExecutableFrom(identifier: "com.something.2", codeRequirement: "testReq2")
         model.selectedExecutables = [executable, executableSecond]
 
-        //when
+        // when
         let existingExecutable = model.getExecutableFromSelectedExecutables(bundleIdentifier: "com.something.1")
 
-        //then
+        // then
         XCTAssertNotNil(existingExecutable)
         XCTAssertEqual(existingExecutable?.identifier, expectedIdentifier)
         XCTAssertEqual(existingExecutable?.displayName, "1")
@@ -101,17 +101,17 @@ class ModelTests: XCTestCase {
     }
 
     func testGetExecutableFromSelectedExecutables_Path() {
-        //given
+        // given
         let expectedIdentifier = "/path/something/Special"
         let executableOneMore = model.getExecutableFrom(identifier: "/path/something/Special1", codeRequirement: "testReq")
         let executable = model.getExecutableFrom(identifier: expectedIdentifier, codeRequirement: "testReq")
         let executableSecond = model.getExecutableFrom(identifier: "com.something.2", codeRequirement: "testReq2")
         model.selectedExecutables = [executableOneMore, executable, executableSecond]
 
-        //when
+        // when
         let existingExecutable = model.getExecutableFromSelectedExecutables(bundleIdentifier: "/path/something/Special")
 
-        //then
+        // then
         XCTAssertNotNil(existingExecutable)
         XCTAssertEqual(existingExecutable?.identifier, expectedIdentifier)
         XCTAssertEqual(existingExecutable?.displayName, "Special")
@@ -119,10 +119,10 @@ class ModelTests: XCTestCase {
     }
 
     func testGetExecutableFromSelectedExecutables_Empty() {
-        //when
+        // when
         let existingExecutable = model.getExecutableFromSelectedExecutables(bundleIdentifier: "com.something.1")
 
-        //then
+        // then
         XCTAssertNil(existingExecutable)
     }
 
@@ -185,7 +185,7 @@ class ModelTests: XCTestCase {
         }
     }
 
-    //swiftlint:disable:next function_body_length
+    // swiftlint:disable:next function_body_length
     func testExportProfileWithAppleEventsAndLegacyAllowed() {
         // given
         let exe1 = Executable(identifier: "one", codeRequirement: "oneReq")


### PR DESCRIPTION
Both the applications list and the Apple Events app list now support multiple apps being dragged in at once.  If an application is already in the list, it is not added a second time.

Fixes #85